### PR TITLE
Fixes test app loading for direct tap runs and VS Code debugger

### DIFF
--- a/tests/versioned/helpers.js
+++ b/tests/versioned/helpers.js
@@ -39,16 +39,19 @@ helpers.build = function build(path = 'app') {
  * @param {number} [port=3001]
  * @returns {Promise}
  */
-helpers.start = function start(path = 'app', port = 3001) {
+helpers.start = async function start(path = 'app', port = 3001) {
+  // Needed to support the various locations tests may get loaded from (versioned VS tap <file> VS IDE debugger)
+  const fullPath = `${__dirname}/${path}`
+
   const { startServer } = require('next/dist/server/lib/start-server')
-  return startServer({
-    dir: path,
+  const app = await startServer({
+    dir: fullPath,
     hostname: 'localhost',
     port
-  }).then(async (app) => {
-    await app.prepare()
-    return app
   })
+
+  await app.prepare()
+  return app
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed start helper to provide full path to the next cli binary.

## Links

## Details
The versioned tests were not working when running `tap tests/versioned/scaffold.tap.js`

```sh
npx tap tests/versioned/scaffold.tap.js

 FAIL  tests/versioned/scaffold.tap.js
 ✖ Could not find a production build in the '/path/to/newrelic-node-nextjs/app/.next' directory. Try building your app with 'next build' before starting the
   production server. https://nextjs.org/docs/messages/production-start-no-build-id

  test: Next.js
  stack: >
    NextNodeServer.getBuildId
    (tests/versioned/node_modules/next/server/next-server.ts:149:15)

    new Server (tests/versioned/node_modules/next/server/base-server.ts:282:25)

    new NextNodeServer (tests/versioned/node_modules/next/server/next-server.ts:98:5)

    NextServer.createServer (tests/versioned/node_modules/next/server/next.ts:124:12)

    tests/versioned/node_modules/next/server/next.ts:140:23
  autoend: true
  at:
    line: 149
    column: 15
    file: tests/versioned/node_modules/next/server/next-server.ts
    function: NextNodeServer.getBuildId

 RUNS  tests/versioned/scaffold.tap.js 1 failed of 1 11s
Suites:   0 of 1 completed
Asserts:  1 failed, of 1
```
