### PR TITLE
fixed create-release.yml to pass in changelog_file as an element of with: and not as a secret

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,6 +5,7 @@ on: [workflow_dispatch]
 jobs:
   tag-and-publish:
     uses: newrelic/node-newrelic/.github/workflows/release-creation.yml@main
+    with:
+      changelog_file: CHANGELOG.md
     secrets:
       npm_token: ${{ secrets.NODE_AGENT_NPM_TOKEN }}
-      changelog_file: CHANGELOG.md


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed create release workflow by properly passing in `changelog_file` via the `with:` keyword and not as a secret.

## Links

## Details
We've never run this as the first release was manual.  Tried running it and failed: https://github.com/newrelic/newrelic-node-nextjs/actions/runs/2091163623/workflow.
