### PR TITLE
Adds an additional path to register next-server instrumentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@
  */
 const newrelic = require('newrelic')
 
+// TODO: Remove once we update agent instrumentation to not rely on full required path within Node.js
+// When running Next.js app as a standalone server this is how the next-server is getting loaded
+// See: https://github.com/vercel/next.js/blob/canary/packages/next/build/utils.ts#L1217
+newrelic.instrumentWebframework('next/dist/server/next-server', require('./lib/next-server'))
 newrelic.instrumentWebframework('./next-server', require('./lib/next-server'))
 newrelic.instrumentWebframework('./render', require('./lib/render'))
 newrelic.instrumentWebframework('./context', require('./lib/context'))


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Adds an additional path to register `next-server` when running a Next.js app with a standalone server.

## Links
Closes #69

## Details
We hope to address this in the agent when we support ESM so we can remove all these weird relative paths and instead probably just do `next/next-server` instead of relying on shaky relative paths that could change depending on how you're using a given library.
