### PR TITLE
updated readme and docs to reflect new conventions for Next.js middleware as of 12.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This module provides instrumentation for server-side rendering via [getServerSid
 
 Here are documents for more in-depth explanations about [transaction naming](./docs/transactions.md), [segments/spans](./docs/segments-and-spans.md), and [injecting the browser agent](./docs/inject-browser-agent.md).
 
-**Note**: The minimum supported Next.js version is [12.0.9](https://github.com/vercel/next.js/releases/tag/v12.0.9).
+**Note**: The minimum supported Next.js version is [12.0.9](https://github.com/vercel/next.js/releases/tag/v12.0.9).  If you are using Next.js middleware the minimum supported version is [12.2.0](https://github.com/vercel/next.js/releases/tag/v12.2.0).
 
 ## Installation
 

--- a/docs/segments-and-spans.md
+++ b/docs/segments-and-spans.md
@@ -4,29 +4,11 @@ Segments and spans (when distributed tracing is enabled) are captured for Next.j
 
 ## Next.js middleware segments/spans
 
-[Next.js middleware](https://nextjs.org/docs/middleware) is currently a beta feature and our instrumentation may be subject to change and/or break during patch, or minor upgrades of Next.js.
+[Next.js middleware](https://nextjs.org/docs/middleware) was made stable in 12.2.0.  As of v0.2.0 of `@newrelic/next`, it will only instrument Next.js middleware in versions greater than or equal to 12.2.0.
 
-`/Nodejs/Middleware/Nextjs/<middleware location>`
+`/Nodejs/Middleware/Nextjs//middleware`
 
-If you have middleware in a deeply nested application, segments and spans will be created for every unique middleware.
-
-```sh
-  pages
-    _middleware.js
-      nested
-        _middleware.js
-          last
-            _middleware.js
-            [id].js
-```
-
-If a request is made to `pages/nested/last/1`, there will be 4 segments:
-
- * `Nodejs/Middleware/Nextjs//_middleware`
- * `Nodejs/Middleware/Nextjs//nested/_middleware`
- * `Nodejs/Middleware/Nextjs//nested/last/_middleware`
- * `Nodejs/Nextjs/getServerSideProps//pages/nested/last/[id]`
-
+Since middleware executes for every request you will see the same span for every request if middleware is present even if you aren't executing any business logic for a given route.  If you have middleware in a deeply nested application, segments and spans will be created for every unique middleware.
 
 ## Server-side rendering segments/spans
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated `README` and segment/span docs to call out middleware behavior in the plugin.
    * Middleware is now stable in Next.js as of 12.2.0, the plugin only supports 12.2.0+.

## Links
Closes #72

## Details
