### PR TITLE
swapped out using fetch for http to fix context propagation issues

### DIFF
--- a/tests/versioned/app/pages/person/[id].js
+++ b/tests/versioned/app/pages/person/[id].js
@@ -4,6 +4,7 @@
  */
 
 import { useRouter } from 'next/router'
+import * as http from 'http'
 
 const Person = ({ user }) => {
   const router = useRouter()
@@ -19,8 +20,17 @@ const Person = ({ user }) => {
 export async function getServerSideProps(context) {
   const { id } = context.params
   const host = context.req.headers.host
-  const user = await fetch(`http://${host}/api/person/${id}`)
-  const data = await user.json()
+  // TODO: Update to use global fetch once agent can properly
+  // propagate context through it
+  const data = await new Promise((resolve, reject) => {
+    http.get(`http://${host}/api/person/${id}`, (res) => {
+      let body = ''
+      res.on('data', (data) => (body += data.toString(('utf8'))))
+      res.on('end', () => {
+        resolve(body)
+      })
+    }).on('error', reject)
+  })
 
   if (!data) {
     return {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated sample app to use `http.get` instead of `fetch` to make subrequests to API to avoid async context propogation breakage in Node 18.

## Links
 * Closes https://issues.newrelic.com/browse/NR-33621

## Details
In Node 18 fetch is a global which is really undici under the hood.  However, our instrumentation for undici doesn't work(still unknown, but most likely the require path isn't undici).  So instead of fixing that for now I ported the one place where global fetch breaks tests and opted to use http.get.
