### PR TITLE
fixed link to support section in troubleshooting link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Troubleshooting
-    url:  https://github.com/newrelic/newrelic-node-apollo-server-plugin/blob/main/README.md#support
+    url:  https://github.com/newrelic/newrelic-node-nextjs/blob/main/README.md#support
     about: Check out the README for troubleshooting directions

--- a/tests/versioned/newrelic.js
+++ b/tests/versioned/newrelic.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+exports.config = {
+  app_name: ['My Application'],
+  license_key: 'license key here'
+}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
The troubleshooting link was going to the apollo plugin readme not next.js plugin readme.

