### PR TITLE
fixed peerDependency newrelic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "newrelic": ">=8.8.0"
+        "newrelic": ">=8.14.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "tap": "^16.2.0"
   },
   "peerDependencies": {
-    "newrelic": ">=8.8.0"
+    "newrelic": ">=8.14.0"
   },
   "dependencies": {
     "semver": "^7.3.7"


### PR DESCRIPTION
## Proposed Release Notes

 * Updated newrelic peer dependency to be >= 8.14.0. This makes the hasToRemoveScriptWrapper property available for api.getBrowserTimingHeader.

## Details

In order to be able to use `api.getBrowserTimingHeader` with `hasToRemoveScriptWrapper: true` the minimum version of `newrelic` is `8.14.0` https://github.com/newrelic/node-newrelic/blob/main/NEWS.md#v8140-2022-06-06
