### PR TITLE
updates versioned tests to run tests on v13 of next.js

### DIFF
--- a/tests/versioned/package.json
+++ b/tests/versioned/package.json
@@ -17,6 +17,21 @@
         "segments.tap.js",
         "transaction-naming.tap.js"
       ]
+    },
+    {
+      "engines": {
+        "node": ">=14"
+      },
+      "dependencies": {
+        "next": ">=13.0.0",
+        "react": "18.2.0",
+        "react-dom": "18.2.0"
+      },
+      "files": [
+        "attributes.tap.js",
+        "segments.tap.js",
+        "transaction-naming.tap.js"
+      ]
     }
   ],
   "dependencies": {}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated versioned tests to include v13 of Next.js.

## Links

## Details
It looks like Next.js released 13.0.0 yesterday and we were just doing caret matching on 12.x.  I had to create a new test stanza as 13 relies on react 18.x now but our instrumentation still works 🎉
