### PR TITLE
fix: updated next server setup to handle 13.3.0 changes

### DIFF
--- a/tests/versioned/attributes.tap.js
+++ b/tests/versioned/attributes.tap.js
@@ -44,7 +44,7 @@ tap.Test.prototype.addAssert('nextCLMAttrs', 1, function ({ segments, clmEnabled
 tap.test('Next.js', (t) => {
   t.autoend()
   let agent
-  let app
+  let server
 
   t.before(async () => {
     await helpers.build(__dirname)
@@ -58,11 +58,11 @@ tap.test('Next.js', (t) => {
 
     // TODO: would be nice to run a new server per test so there are not chained failures
     // but currently has issues. Potentially due to module caching.
-    app = await helpers.start(__dirname)
+    server = await helpers.start(__dirname)
   })
 
-  t.teardown(() => {
-    app.options.httpServer.close()
+  t.teardown(async () => {
+    await server.close()
     agent.unload()
   })
 

--- a/tests/versioned/helpers.js
+++ b/tests/versioned/helpers.js
@@ -12,6 +12,10 @@ const tap = require('tap')
 const utils = require('@newrelic/test-utilities')
 utils.assert.extendTap(tap)
 
+const nextPkg = require('next/package.json')
+const semver = require('semver')
+const newServerResponse = semver.gte(nextPkg.version, '13.3.0')
+
 /**
  * Builds a Next.js app
  * @param {sting} dir directory to run next cli in
@@ -56,8 +60,13 @@ helpers.start = async function start(dir, path = 'app', port = 3001) {
     allowRetry: true
   })
 
+  if (newServerResponse) {
+    // app is actually a shutdown function, so wrap it for convenience
+    return { close: app }
+  }
+
   await app.prepare()
-  return app
+  return app.options.httpServer
 }
 
 /**

--- a/tests/versioned/segments.tap.js
+++ b/tests/versioned/segments.tap.js
@@ -33,7 +33,7 @@ function getChildSegments(uri) {
 tap.test('Next.js', (t) => {
   t.autoend()
   let agent
-  let app
+  let server
 
   t.before(async () => {
     agent = utils.TestAgent.makeInstrumented()
@@ -46,11 +46,11 @@ tap.test('Next.js', (t) => {
     require.cache.__NR_cache = agent.agent
     helpers.registerInstrumentation(agent)
     await helpers.build(__dirname)
-    app = await helpers.start(__dirname)
+    server = await helpers.start(__dirname)
   })
 
-  t.teardown(() => {
-    app.options.httpServer.close()
+  t.teardown(async () => {
+    await server.close()
     agent.unload()
   })
 

--- a/tests/versioned/transaction-naming.tap.js
+++ b/tests/versioned/transaction-naming.tap.js
@@ -14,7 +14,7 @@ const NEXT_TRANSACTION_PREFIX = 'WebTransaction/WebFrameworkUri/Nextjs/GET/'
 tap.test('Next.js', (t) => {
   t.autoend()
   let agent
-  let app
+  let server
 
   t.before(async () => {
     await helpers.build(__dirname)
@@ -28,11 +28,11 @@ tap.test('Next.js', (t) => {
 
     // TODO: would be nice to run a new server per test so there are not chained failures
     // but currently has issues. Potentially due to module caching.
-    app = await helpers.start(__dirname)
+    server = await helpers.start(__dirname)
   })
 
-  t.teardown(() => {
-    app.options.httpServer.close()
+  t.teardown(async () => {
+    await server.close()
     agent.unload()
   })
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links
Closes #115 

## Details
Next.js@13.3.0 updated their return value of `startServer`. Previous versions returned an object that had the HTTP Server attached as a property, and we used that to setup/teardown our server. 13.3.0 changed the return value of `startServer` to just the teardown function to shutdown the server. These changes make it so tests work for both previous versions, as well as the latest.