### PR TITLE
fix: updated readme to call out that this package is not bundled with agent yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 
 This is New Relic's official Next.js framework instrumentation for use with the New Relic [Node.js agent](https://github.com/newrelic/node-newrelic).
 
-This module is a dependency of the agent and is installed by default when you install the agent.
-
 This module provides instrumentation for server-side rendering via [getServerSideProps](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props), [middleware](https://nextjs.org/docs/middleware), and New Relic transaction naming for both page and server requests. It does not provide any instrumentation for actions occurring during build or in client-side code.  If you want telemetry data on actions occurring on the client (browser), you can [inject the browser agent](./docs/inject-browser-agent.md).
 
 Here are documents for more in-depth explanations about [transaction naming](./docs/transactions.md), [segments/spans](./docs/segments-and-spans.md), and [injecting the browser agent](./docs/inject-browser-agent.md).
@@ -15,9 +13,7 @@ Here are documents for more in-depth explanations about [transaction naming](./d
 
 ## Installation
 
-Typically, most users use the version auto-installed by the agent. You can see agent install instructions [here](https://github.com/newrelic/node-newrelic#installation-and-getting-started).
-
-In some cases, installing a specific version is ideal. For example, new features or major changes might be released via a major version update to this module, prior to inclusion in the main New Relic Node.js agent.
+Currently this package is not bundled with the agent, and must be installed as a standalone.  However, the package depends on the agent so you will get all the capabilities of the agent when loading this package.
 
 ```
 npm install @newrelic/next


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
We haven't bundled this with the agent yet.  I think because we wanted users to use it and give us feedback before moving to 1.x and bundling with agent.  We currently have a few issues: doesn't work with 13.3.1+ and we aren't supporting some newer constructs.  We need to prioritize that work before bumping to 1.x and bundling so until then I updated README.
