### PR TITLE
chore: change node engine to 16

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -34,7 +34,7 @@ code, the source code can be found at [https://github.com/newrelic/newrelic-node
 
 ### semver
 
-This product includes source derived from [semver](https://github.com/npm/node-semver) ([v7.3.8](https://github.com/npm/node-semver/tree/v7.3.8)), distributed under the [ISC License](https://github.com/npm/node-semver/blob/v7.3.8/LICENSE):
+This product includes source derived from [semver](https://github.com/npm/node-semver) ([v7.5.4](https://github.com/npm/node-semver/tree/v7.5.4)), distributed under the [ISC License](https://github.com/npm/node-semver/blob/v7.5.4/LICENSE):
 
 ```
 The ISC License
@@ -964,7 +964,7 @@ This product includes source derived from [lockfile-lint](https://github.com/lir
 
 ### newrelic
 
-This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v10.0.0](https://github.com/newrelic/node-newrelic/tree/v10.0.0)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v10.0.0/LICENSE):
+This product includes source derived from [newrelic](https://github.com/newrelic/node-newrelic) ([v10.4.2](https://github.com/newrelic/node-newrelic/tree/v10.4.2)), distributed under the [Apache-2.0 License](https://github.com/newrelic/node-newrelic/blob/v10.4.2/LICENSE):
 
 ```
                                  Apache License

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "tap": "^16.2.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16.0.0"
       },
       "peerDependencies": {
         "newrelic": ">=8.14.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/newrelic/newrelic-node-nextjs#readme",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "devDependencies": {
     "@newrelic/eslint-config": "^0.2.0",

--- a/tests/versioned/package.json
+++ b/tests/versioned/package.json
@@ -5,21 +5,6 @@
   "tests": [
     {
       "engines": {
-        "node": ">=14"
-      },
-      "dependencies": {
-        "next": "^12.0.9",
-        "react": "17.0.2",
-        "react-dom": "17.0.2"
-      },
-      "files": [
-        "attributes.tap.js",
-        "segments.tap.js",
-        "transaction-naming.tap.js"
-      ]
-    },
-    {
-      "engines": {
         "node": ">=16"
       },
       "dependencies": {

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,19 +1,19 @@
 {
-  "lastUpdated": "Tue Jul 11 2023 11:56:06 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Wed Aug 09 2023 12:33:11 GMT+0300 (Eastern European Summer Time)",
   "projectName": "New Relic Next.js Instrumentation",
   "projectUrl": "https://github.com/newrelic/newrelic-node-nextjs",
   "includeOptDeps": false,
   "includeDev": true,
   "dependencies": {
-    "semver@7.3.8": {
+    "semver@7.5.4": {
       "name": "semver",
-      "version": "7.3.8",
+      "version": "7.5.4",
       "range": "^7.3.7",
       "licenses": "ISC",
       "repoUrl": "https://github.com/npm/node-semver",
-      "versionedRepoUrl": "https://github.com/npm/node-semver/tree/v7.3.8",
+      "versionedRepoUrl": "https://github.com/npm/node-semver/tree/v7.5.4",
       "licenseFile": "node_modules/semver/LICENSE",
-      "licenseUrl": "https://github.com/npm/node-semver/blob/v7.3.8/LICENSE",
+      "licenseUrl": "https://github.com/npm/node-semver/blob/v7.5.4/LICENSE",
       "licenseTextSource": "file",
       "publisher": "GitHub Inc."
     }
@@ -110,15 +110,15 @@
       "email": "liran.tal@gmail.com",
       "url": "https://github.com/lirantal"
     },
-    "newrelic@10.0.0": {
+    "newrelic@10.4.2": {
       "name": "newrelic",
-      "version": "10.0.0",
-      "range": "^10.0.0",
+      "version": "10.4.2",
+      "range": "^10.3.1",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/node-newrelic",
-      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v10.0.0",
+      "versionedRepoUrl": "https://github.com/newrelic/node-newrelic/tree/v10.4.2",
       "licenseFile": "node_modules/newrelic/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v10.0.0/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/node-newrelic/blob/v10.4.2/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
## Proposed Release Notes
* **BREAKING** - Dropped support for Node 14. 

## Links
-Closes #139 

## Details
- Removed versioned tests for Node 14
- Update package.json engine to 16