### PR TITLE
fix: updated instrumentation to skip registering middleware instrumentation as it runs in a worker thread now and our agent cannot properly track async context

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,7 @@
  */
 
 'use strict'
+const semver = require('semver')
 const utils = module.exports
 
 /**
@@ -28,4 +29,30 @@ utils.assignCLMAttrs = function assignCLMAttrs(config, segment, attrs) {
   for (const [key, value] of Object.entries(attrs)) {
     segment.addAttribute(key, value)
   }
+}
+
+// Version middleware is stable
+// See: https://nextjs.org/docs/advanced-features/middleware
+const MIN_MW_SUPPORTED_VERSION = '12.2.0'
+// Middleware moved to worker thread
+// We plan on revisiting when we release a stable version of our Next.js instrumentation
+const MAX_MW_SUPPORTED_VERSION = '13.4.12'
+
+utils.MAX_MW_SUPPORTED_VERSION = MAX_MW_SUPPORTED_VERSION
+utils.MIN_MW_SUPPORTED_VERSION = MIN_MW_SUPPORTED_VERSION
+/**
+ * Middlware instrumentation has had quite the journey for us.
+ * As of 8/7/23 it no longer functions because it is running in a worker thread.
+ * Our instrumentation cannot propagate context in threads so for now we will no longer record this
+ * span.
+ *
+ * @param {string} version next.js version
+ * @returns {boolean} is middleware instrumentation supported
+ */
+utils.isMiddlewareInstrumentationSupported = function isMiddlewareInstrumentationSupported(
+  version
+) {
+  return (
+    semver.gte(version, MIN_MW_SUPPORTED_VERSION) && semver.lte(version, MAX_MW_SUPPORTED_VERSION)
+  )
 }

--- a/tests/unit/next-server.test.js
+++ b/tests/unit/next-server.test.js
@@ -66,7 +66,7 @@ tap.test('middleware tracking', (t) => {
     t.equal(shim.logger.warn.callCount, 1, 'should log warn message')
     const loggerArgs = shim.logger.warn.args[0]
     t.same(loggerArgs, [
-      'Next.js middleware instrumentation only supported on >=12.2.0, got %s',
+      'Next.js middleware instrumentation only supported on >=12.2.0 <=13.4.12, got %s',
       '12.0.1'
     ])
     t.notOk(

--- a/tests/versioned/attributes.tap.js
+++ b/tests/versioned/attributes.tap.js
@@ -9,8 +9,8 @@ const tap = require('tap')
 const helpers = require('./helpers')
 const utils = require('@newrelic/test-utilities')
 const nextPkg = require('next/package.json')
-const semver = require('semver')
-const middlewareSupported = semver.gte(nextPkg.version, '12.2.0')
+const { isMiddlewareInstrumentationSupported } = require('../../lib/utils')
+const middlewareSupported = isMiddlewareInstrumentationSupported(nextPkg.version)
 
 const DESTINATIONS = {
   NONE: 0x00,

--- a/tests/versioned/helpers.js
+++ b/tests/versioned/helpers.js
@@ -55,7 +55,7 @@ helpers.start = async function start(dir, path = 'app', port = 3001) {
   const { startServer } = require(`${dir}/node_modules/next/dist/server/lib/start-server`)
   const app = await startServer({
     dir: fullPath,
-    hostname: 'localhost',
+    hostname: '0.0.0.0',
     port,
     allowRetry: true
   })
@@ -77,7 +77,7 @@ helpers.start = async function start(dir, path = 'app', port = 3001) {
  * @returns {Promise}
  */
 helpers.makeRequest = function (uri, port = 3001) {
-  const url = `http://localhost:${port}${uri}`
+  const url = `http://0.0.0.0:${port}${uri}`
   return new Promise((resolve, reject) => {
     http
       .get(url, (res) => {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated instrumentation to no longer record spans for middleware execution.
 * Updated instrumentation for api requests to properly extract the params and page.

## Links
Closes #144

## Details
13.4.13 has yet another refactor that impacts our instrumentation. `runApi` signature has changed so the means of extracting the page and params vary.  The bigger issue is that we can no longer record middleware spans.  It appears that the execution  only runs in [worker threads](https://github.com/vercel/next.js/pull/52492/files#diff-c49c4767e6ed8627e6e1b8f96b141ee13246153f5e9142e1da03450c8e81e96f). 

Now in `next/src/server/base-server.ts` `handleCatchallMiddlewareRequest` only gets called if `__NEXT_PRIVATE_RENDER_WORKER` exists which gets assigned to all workers and if a header of `  req.headers['x-middleware-invoke']` is present.  Until our agent significantly changes, if ever, to propagate into worker threads we have to skip this instrumentation/test assertion.

```ts
if (
        process.env.NEXT_RUNTIME !== 'edge' &&
        process.env.__NEXT_PRIVATE_RENDER_WORKER &&
        req.headers['x-middleware-invoke']
      ) {
        const nextDataResult = await this.normalizeNextData(req, res, parsedUrl)

        if (nextDataResult.finished) {
          return
        }
        const result = await this.handleCatchallMiddlewareRequest(
          req,
          res,
          parsedUrl
        )
```