### PR TITLE
remove slack link as it is decommissioned

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,12 +32,9 @@ For more information about CLAs, please check out Alex Russell’s excellent
 post, [“Why Do I Need to Sign
 This?”](https://infrequently.org/2008/06/why-do-i-need-to-sign-this/).
 
-### Slack
+### Engage and Collaborate on our Forum
 
-We host a public Slack with a dedicated channel for contributors and
-maintainers of open source projects hosted by New Relic. If you are
-contributing to this project, you're welcome to request access to the
-\#oss-contributors channel in the newrelicusers.slack.com workspace. To request access, please use this [link](https://join.slack.com/t/newrelicusers/shared_invite/zt-1ayj69rzm-~go~Eo1whIQGYnu3qi15ng).
+We host a public forum with dedicated categories for contributors and maintainers of open source projects hosted by New Relic. For all discussions and support, please visit our [forum](https://forum.newrelic.com/s/category/Category__c/Default).
 
 ## PR Guidelines
 


### PR DESCRIPTION
## Proposed Release Notes

Updated the contributing docs

## Links
closes #146

## Details

remove slack link as it is decommissioned instead added the forum link
 
