### PR TITLE
feat: Updated instrumentation to handle instrumenting instance vs prototype.

### DIFF
--- a/lib/next-server.js
+++ b/lib/next-server.js
@@ -14,15 +14,15 @@ const {
 const SPAN_PREFIX = 'Nodejs/Nextjs'
 const GET_SERVER_SIDE_PROP_VERSION = '13.4.5'
 
-module.exports = function initialize(shim, nextServer) {
+module.exports = function initialize(shim, nextServer, _moduleName, instance) {
   const nextVersion = shim.require('./package.json').version
   const { config } = shim.agent
   shim.setFramework(shim.NEXT)
 
-  const Server = nextServer.default
+  const Server = instance ? nextServer : nextServer?.default?.prototype
 
   shim.wrap(
-    Server.prototype,
+    Server,
     'renderToResponseWithComponents',
     function wrapRenderToResponseWithComponents(shim, originalFn) {
       return function wrappedRenderToResponseWithComponents() {
@@ -65,7 +65,7 @@ module.exports = function initialize(shim, nextServer) {
     }
   )
 
-  shim.wrap(Server.prototype, 'runApi', function wrapRunApi(shim, originalFn) {
+  shim.wrap(Server, 'runApi', function wrapRunApi(shim, originalFn) {
     return function wrappedRunApi() {
       const { page, params } = extractAttrs(arguments, nextVersion)
 
@@ -83,7 +83,7 @@ module.exports = function initialize(shim, nextServer) {
 
   if (semver.lt(nextVersion, GET_SERVER_SIDE_PROP_VERSION)) {
     shim.record(
-      Server.prototype,
+      Server,
       'renderHTML',
       function renderHTMLRecorder(shim, renderToHTML, name, [req, res, page]) {
         return {
@@ -112,7 +112,7 @@ module.exports = function initialize(shim, nextServer) {
   }
 
   shim.record(
-    Server.prototype,
+    Server,
     'runMiddleware',
     function runMiddlewareRecorder(shim, runMiddleware, name, [args]) {
       const middlewareName = 'middleware'

--- a/tests/unit/next-server.test.js
+++ b/tests/unit/next-server.test.js
@@ -75,4 +75,15 @@ tap.test('middleware tracking', (t) => {
     )
     t.end()
   })
+
+  t.test('should instrument instance of next server and not prototype', (t) => {
+    const NewFakeServer = createMockServer()
+    const server = new NewFakeServer()
+    initialize(shim, server, 'next', true)
+    t.ok(shim.isWrapped(server.runMiddleware))
+    t.ok(shim.isWrapped(server.runApi))
+    t.ok(shim.isWrapped(server.renderHTML))
+    t.ok(shim.isWrapped(server.renderToResponseWithComponents))
+    t.end()
+  })
 })


### PR DESCRIPTION
This will facilitate instrumenting next-server in cloud providers when
we use the instrumentationHook functionality.

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated instrumentation to handle instrumenting instance vs prototype.

## Links

## Details
This is preparing for the eventual merge of a PR I added [here](https://github.com/vercel/next.js/pull/55412/files).  The idea is once this lands and is released, we can provide a new function that our customers can put into their instrumentation.js within their Next.js project.  The hope is this will be the solution for getting Next.js instrumentation into Vercel, AWS Amplify, etc.  I'm trying to test on those services but it's very difficult to get all this in flight work bundled and into my Next.js app I'm deploying.  

This is the sample function I added into instrumentation.js

```js
export async function register(nextServer) {
  if (process.env.NEXT_RUNTIME === 'nodejs') {
    const { default: nextInstrumentation } = await import('@newrelic/next/lib/next-server.js')
    const newrelic = await import('newrelic')
    const shims = await import('newrelic/lib/shim/index.js')
    const moduleName = 'next/dist/server/next-server'
    const shim = shims.createShimFromType(shims.constants.MODULE_TYPE.WEB_FRAMEWORK, newrelic.agent, moduleName, nextServer.dir + '/node_modules/next') 
    nextInstrumentation(shim, nextServer, moduleName, true)
  }
}
```

The idea would be we'd provide all of this in a function within this repo.

So it'd look like this

```js
export async function register(nextServer) {
  if (process.env.NEXT_RUNTIME === 'nodejs') {
    await import('@newrelic/next/register')
  }
}
```
