### PR TITLE
test: skip running Next 14+ versioned tests on Node 16 as support was dropped

### DIFF
--- a/tests/versioned/package.json
+++ b/tests/versioned/package.json
@@ -8,7 +8,22 @@
         "node": ">=16"
       },
       "dependencies": {
-        "next": ">=13.0.0",
+        "next": ">=13.0.0 <14",
+        "react": "18.2.0",
+        "react-dom": "18.2.0"
+      },
+      "files": [
+        "attributes.tap.js",
+        "segments.tap.js",
+        "transaction-naming.tap.js"
+      ]
+    },
+    {
+      "engines": {
+        "node": ">=18"
+      },
+      "dependencies": {
+        "next": ">=14.0.0",
         "react": "18.2.0",
         "react-dom": "18.2.0"
       },


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
Next 14 dropped Node 16 support, this PR skips those tests from running.
