### PR TITLE
test: updated test assertions based on segment tree changes in 14.1.0 of Next.js

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,3 +56,16 @@ utils.isMiddlewareInstrumentationSupported = function isMiddlewareInstrumentatio
     semver.gte(version, MIN_MW_SUPPORTED_VERSION) && semver.lte(version, MAX_MW_SUPPORTED_VERSION)
   )
 }
+
+/**
+ * Depending on the Next.js version the segment tree varies as it adds setTimeout segments.
+ * This util will find the segment that has `getServerSideProps` in the name
+ *
+ * @param {object} rootSegment trace root
+ * @returns {object} getServerSideProps segment
+ */
+utils.getServerSidePropsSegment = function getServerSidePropsSegment(rootSegment) {
+  return rootSegment.children[0].children.find((segment) =>
+    segment.name.includes('getServerSideProps')
+  )
+}

--- a/tests/versioned/attributes.tap.js
+++ b/tests/versioned/attributes.tap.js
@@ -9,7 +9,10 @@ const tap = require('tap')
 const helpers = require('./helpers')
 const utils = require('@newrelic/test-utilities')
 const nextPkg = require('next/package.json')
-const { isMiddlewareInstrumentationSupported } = require('../../lib/utils')
+const {
+  isMiddlewareInstrumentationSupported,
+  getServerSidePropsSegment
+} = require('../../lib/utils')
 const middlewareSupported = isMiddlewareInstrumentationSupported(nextPkg.version)
 
 const DESTINATIONS = {
@@ -267,7 +270,7 @@ tap.test('Next.js', (t) => {
         })
       } else {
         segments.push({
-          segment: rootSegment.children[0].children[0],
+          segment: getServerSidePropsSegment(rootSegment),
           name: 'getServerSideProps',
           filepath: 'pages/ssr/people'
         })

--- a/tests/versioned/segments.tap.js
+++ b/tests/versioned/segments.tap.js
@@ -28,12 +28,6 @@ function getChildSegments(uri) {
     })
   }
 
-  if (semver.gte(nextPkg.version, '13.4.5')) {
-    segments.push({
-      name: 'timers.setTimeout'
-    })
-  }
-
   return segments
 }
 
@@ -75,7 +69,6 @@ tap.test('Next.js', (t) => {
     const expectedSegments = [
       {
         name: `${TRANSACTION_PREFX}${URI}`,
-        exact: true,
         children: getChildSegments(URI)
       }
     ]
@@ -97,7 +90,6 @@ tap.test('Next.js', (t) => {
     const expectedSegments = [
       {
         name: `${TRANSACTION_PREFX}${EXPECTED_URI}`,
-        exact: true,
         children: getChildSegments(EXPECTED_URI)
       }
     ]
@@ -126,7 +118,6 @@ tap.test('Next.js', (t) => {
       ]
 
       if (semver.gte(nextPkg.version, '12.2.0')) {
-        expectedSegments[0].exact = true
         expectedSegments[0].children = [
           {
             name: `${MW_PREFIX}/middleware`


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
The nightly versioned tests were failing on Next.js. It was determined that the segment tree structure changed.  I updated the tests to be less rigid and properly asserting the relevant segments.
