### PR TITLE
fix: add missing quotation mark in faq docs

### DIFF
--- a/docs/faqs/cloud-providers.md
+++ b/docs/faqs/cloud-providers.md
@@ -54,7 +54,7 @@ sdk.start()
 ```js
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
-    require('./new-relic-instrumentation.js)
+    require('./new-relic-instrumentation.js')
   }
 }
 ```


### PR DESCRIPTION
## Description

Updated the `register` function in `instrumentation.ts` to fix a typo by adding a missing quotation mark.

## How to Test

No testing is required for this documentation-only change.

## Related Issues

None